### PR TITLE
PCK certificate chain extractor / getter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,6 +324,7 @@ impl CertificationDataInner {
             3 => Ok(Self::PckIdPpidRSA3072CpusvnPcesvn(data)),
             4 => Ok(Self::PckLeafCert(data)),
             5 => Ok(Self::PckCertChain(data)),
+            // No 6 because that would be a recursive type
             7 => Ok(Self::PlatformManifest(data)),
             _ => Err(QuoteParseError::UnknownCertificationDataType),
         }

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -18,6 +18,9 @@ fn test_parse() {
         file.read_to_end(&mut input).unwrap();
         let quote = Quote::from_bytes(&input).unwrap();
 
+        // Check we can get the PCK certificate chain
+        assert!(quote.pck_cert_chain().is_some());
+
         // We currently don't have any v5 quotes to test with
         assert_eq!(quote.header.version, 4);
 

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -50,6 +50,7 @@ fn test_create_mock_quote() {
         attestation_key.clone(),
         provisioning_certification_key.clone(),
         [0; 64],
+        b"Mock cert chain".to_vec(),
     );
     assert_eq!(quote.attestation_key, VerifyingKey::from(attestation_key));
     quote


### PR DESCRIPTION
Allow us to get the PCK cert chain from a quote, if one is present.

Currently. parsing the certificate chain itself is outside the scope of this crate.